### PR TITLE
add_form_character_count_function

### DIFF
--- a/app/assets/javascripts/count.js
+++ b/app/assets/javascripts/count.js
@@ -1,0 +1,83 @@
+$(function (){
+  // 処理（ページが読み込まれた時、フォームに残り何文字入力できるかを数えて表示する）
+  // フォームに入力されている文字数を数える
+  // \nは"改行"に変換して2文字にする。オプションフラグgで文字列の最後まで\nを探し変換する
+  var count = $("#js_phrase").text().replace(/\n/g, "改行").length;
+  // 残りの入力できる文字数を計算
+  var now_count = 60 - count;
+  // 文字数がオーバーしていたら文字色を赤にする
+  if (count > 60) {
+    $(".js_phrase_count").css("color","red");
+  }
+  // 残りの入力できる文字数を表示
+  $(".js_phrase_count").text( "残り" + now_count + "文字");
+  $("#js_phrase").on("keyup", function() {
+    // 処理（キーボードを押した時、フォームに残り何文字入力できるかを数えて表示する）
+    // フォームのvalueの文字数を数える
+    var count = $(this).val().replace(/\n/g, "改行").length;
+    var now_count = 60 - count;
+    if (count > 60) {
+      $(".js_phrase_count").css("color","red");
+    } else {
+      $(".js_phrase_count").css("color","#666");
+    }
+    $(".js_phrase_count").text( "残り" + now_count + "文字");
+  });
+});
+
+$(function (){
+  var count = $("#js_title").text().replace(/\n/g, "改行").length;
+  var now_count = 20 - count;
+  if (count > 20) {
+    $(".js_title_count").css("color","red");
+  }
+  $(".js_title_count").text( "残り" + now_count + "文字");
+  $("#js_title").on("keyup", function() {
+    var count = $(this).val().replace(/\n/g, "改行").length;
+    var now_count = 20 - count;
+    if (count > 20) {
+      $(".js_title_count").css("color","red");
+    } else {
+      $(".js_title_count").css("color","#666");
+    }
+    $(".js_title_count").text( "残り" + now_count + "文字");
+  });
+});
+
+$(function (){
+  var count = $("#js_author").text().replace(/\n/g, "改行").length;
+  var now_count = 12 - count;
+  if (count > 12) {
+    $(".js_author_count").css("color","red");
+  }
+  $(".js_author_count").text( "残り" + now_count + "文字");
+  $("#js_author").on("keyup", function() {
+    var count = $(this).val().replace(/\n/g, "改行").length;
+    var now_count = 12 - count;
+    if (count > 12) {
+      $(".js_author_count").css("color","red");
+    } else { 
+      $(".js_author_count").css("color","#666");
+    }
+    $(".js_author_count").text( "残り" + now_count + "文字");
+  });
+});
+
+$(function (){
+  var count = $("#js_text").text().replace(/\n/g, "改行").length;
+  var now_count = 130 - count;
+  if (count > 130) {
+    $(".js_text_count").css("color","red");
+  }
+  $(".js_text_count").text( "残り" + now_count + "文字");
+  $("#js_text").on("keyup", function() {
+    var count = $(this).val().replace(/\n/g, "改行").length;
+    var now_count = 130 - count;
+    if (count > 130) {
+      $(".js_text_count").css("color","red");
+    } else {
+      $(".js_text_count").css("color","#666");
+    }
+    $(".js_text_count").text( "残り" + now_count + "文字");
+  });
+});

--- a/app/assets/stylesheets/posts/_new.scss
+++ b/app/assets/stylesheets/posts/_new.scss
@@ -34,6 +34,30 @@
       border-radius: 5px;
       font-family: "游ゴシック", "YuGothic";
     }
+    .js_phrase_count {
+      text-align: right;
+      font-size: 12px;
+      color: #666;
+      margin-top: -11px;
+    }
+    .js_title_count {
+      text-align: right;
+      font-size: 12px;
+      color: #666;
+      margin-top: -11px;
+    }
+    .js_author_count {
+      text-align: right;
+      font-size: 12px;
+      color: #666;
+      margin-top: -11px;
+    }
+    .js_text_count {
+      text-align: right;
+      font-size: 12px;
+      color: #666;
+      margin-top: -15px;
+    }
     .posting_image {
       margin: auto;
     }

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -7,13 +7,17 @@
           編集する
         = render 'layouts/error_messages', model: form.object
         %p フレーズ
-        = form.text_field :text,         class: "posting_input", placeholder: "60文字以内"
+        = form.text_field :text,         class: "posting_input", id: "js_phrase", placeholder: "60文字以内"
+        .js_phrase_count
         %p タイトル
-        = form.text_field :title,        class: "posting_input", placeholder: "20文字以内"
+        = form.text_field :title,        class: "posting_input", id: "js_title",  placeholder: "20文字以内"
+        .js_title_count
         %p 著者
-        = form.text_field :author,       class: "posting_input", placeholder: "12文字以内"
+        = form.text_field :author,       class: "posting_input", id: "js_author", placeholder: "12文字以内"
+        .js_author_count
         %p 説明
-        = form.text_area :introduction,  class: "posting_input", placeholder: "130文字以内", rows: "6"
+        = form.text_area :introduction,  class: "posting_input", id: "js_text",   placeholder: "130文字以内", rows: "4"
+        .js_text_count
         %p 画像
         %p (変更する場合のみ選択してください)
         = form.file_field :image,        class: "posting_image"

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -5,13 +5,17 @@
       = form_with(model: @post, local: true) do |form|
         = render 'layouts/error_messages', model: form.object
         %p フレーズ
-        = form.text_field :text,         class: "posting_input", placeholder: "60文字以内", autofocus: true
+        = form.text_field :text,         class: "posting_input", id: "js_phrase", placeholder: "60文字以内", autofocus: true
+        .js_phrase_count
         %p タイトル
-        = form.text_field :title,        class: "posting_input", placeholder: "20文字以内"
+        = form.text_field :title,        class: "posting_input", id: "js_title",  placeholder: "20文字以内"
+        .js_title_count
         %p 著者
-        = form.text_field :author,       class: "posting_input", placeholder: "12文字以内"
+        = form.text_field :author,       class: "posting_input", id: "js_author", placeholder: "12文字以内"
+        .js_author_count
         %p 説明
-        = form.text_area  :introduction, class: "posting_input", placeholder: "130文字以内", rows: "6"
+        = form.text_area  :introduction, class: "posting_input", id: "js_text",   placeholder: "130文字以内", rows: "4"
+        .js_text_count
         %p 画像
         = form.file_field :image,        class: "posting_image"
         = form.submit "投稿", class: "posting_submit_btn"


### PR DESCRIPTION
## What
投稿フォームにjQueryを用いて文字数カウント機能を追加する。

## Why
・長い投稿フォームに文字数カウント機能を追加することで、UI/UXが向上するため。
・文字数のバリデーションエラーにより、ユーザが離れるのを防ぐため。